### PR TITLE
addint support for application gated teams

### DIFF
--- a/symposion/teams/templatetags/teams_tags.py
+++ b/symposion/teams/templatetags/teams_tags.py
@@ -23,7 +23,7 @@ class AvailableTeamsNode(template.Node):
         teams = []
         for team in Team.objects.all():
             state = team.get_state_for_user(request.user)
-            if team.access == "open" and state is None:
+            if team.access in ("open", "application") and state is None:
                 teams.append(team)
             elif request.user.is_staff and state is None:
                 teams.append(team)


### PR DESCRIPTION
Adding a check for "application" to the template tags for teams. This should make any teams that require approval show up in the dashboard. 